### PR TITLE
Don't use comments in yaml example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Installation
     // app/config/config.yml
     // ...
     chat:
-	# refresh interval in milliseconds
+        # refresh interval in milliseconds
         update_interval: 5000
-	# messages to be shown in chat
+        # messages to be shown in chat
         number_of_messages: 10
     ```
 


### PR DESCRIPTION
If someone cuts/pastes the yaml config example from the README, the chat box won't refresh since the comment is considered part of the node.  This PR moves the comment out of the node and places it above the variable.
