### PR TITLE
Don't require page reload to post message

### DIFF
--- a/Controller/ChatController.php
+++ b/Controller/ChatController.php
@@ -45,7 +45,7 @@ class ChatController extends Controller
         $this->getDoctrine()->getManager()->persist($message);
         $this->getDoctrine()->getManager()->flush();
 
-        return $this->redirect($request->headers->get('referer'));
+        return new Response('Successful');
     }
 
     /**

--- a/Resources/views/Chat/show.html.twig
+++ b/Resources/views/Chat/show.html.twig
@@ -7,12 +7,19 @@
 <script type="text/javascript">
 $("#chatForm").submit(function() {
     postMessage();
-    updateChat();
     return false;
 });
 function postMessage()
 {
-    $.post('{{ path('cunningsoft_chat_post') }}', { 'message': $("#chatMessage").val() });
+    $.post('{{ path('cunningsoft_chat_post', {'channel': channel}) }}', 
+           { 'message': $("#chatMessage").val() },
+           function(data) {
+             // Check that the post function completed
+             if (data === 'Successful') {
+               updateChat();
+             }
+           }
+          );
     $("#chatMessage").val('');
 }
 function updateChat()


### PR DESCRIPTION
This PR uses jQuery to post the message and update the listing.  I pulled the setTimeout function out of the updateChat function so that I can call it after the post.  If I would've left it in there, you end up with multiple interval refreshes.  Also changed from setTimeout to setInterval since it's no l longer recreating the timeout each call now.
